### PR TITLE
Make Scratch vs instead of sp with one rectification

### DIFF
--- a/plugin/Scratch.vim
+++ b/plugin/Scratch.vim
@@ -61,6 +61,16 @@ function! <SID>ToggleScratchWin() "{{{
 	endif
 endfunction "}}}
 
+function! <SID>ForceOpenScratchWin() "{{{
+  call s:OpenScratchWin()
+endfunction "}}}
+
+function! <SID>ForceCloseScratchWin() "{{{
+  call s:CloseScratchWin()
+endfunction "}}}
+
 if !exists(":Scratch")
 	command! -nargs=0 Scratch call <SID>ToggleScratchWin()
+	command! -nargs=0 ScratchO call <SID>ForceOpenScratchWin()
+	command! -nargs=0 ScratchC call <SID>ForceCloseScratchWin()
 endif

--- a/plugin/Scratch.vim
+++ b/plugin/Scratch.vim
@@ -16,22 +16,18 @@ let s:sc_bufname = 'Scratch'
 
 function! s:OpenScratchWin() "{{{
 	"first see if the scratch buffer even exists
-	if !exists("g:scratchWinheight")
-		let g:scratchWinheight = 10
-	endif
 	if !bufexists(s:sc_bufname) && bufnr("*/".s:sc_bufname."$") == -1
-		"create new buffer if not existant
-		execute "bot " . g:scratchWinheight . "new " . s:sc_bufname
+		"create vsplit buffer if not existant
+		execute "bot vsplit " . s:sc_bufname
 		setlocal buftype=nofile
 		setlocal bufhidden=hide
 		setlocal noswapfile
 	elseif ( bufwinnr(s:sc_bufname) > 0)
 		"window exists and is visible, switch to it
-		execute bufwinnr(s:sc_bufname) . "wincmd W"
-		"execute "res " . g:scratchWinheight
+		execute bufwinnr(s:sc_bufname) . "wincmd w"
 	else
-		"window must be closed, make a new one
-		execute "bot " . g:scratchWinheight ."new"
+		"window must be closed, make a vsplit buffer
+		execute "bot vsplit"
 		execute "b ".bufnr(s:sc_bufname)
 	endif
 	let g:scratchWinOpen = 1
@@ -41,12 +37,18 @@ function! s:CloseScratchWin() "{{{
 	if ( bufwinnr(s:sc_bufname) > 0)
 		"window exists and is visible, close it
 		let l:curWin = bufwinnr("%")
+    if (l:curWin == bufwinnr(s:sc_bufname))
+      "switch to other buffer,
+      execute "wincmd w"
+      "Get buf number of this witched window
+      let l:curWin = bufwinnr("%")
+    endif
 		"switch to scratch buffer, 
-		execute bufwinnr(s:sc_bufname) . "wincmd W"
+		execute bufwinnr(s:sc_bufname) . "wincmd w"
 		"close it,
 		execute bufwinnr(s:sc_bufname) . "wincmd c"
 		"switch back to original buf
-		execute l:curWin . "wincmd W"
+		execute l:curWin . "wincmd w"
 		let g:scratchWinOpen = 0
 	endif
 endfunction "}}}


### PR DESCRIPTION
Changes,
  + Removed horizontal split and its related height content
  + Instead made it vertical split (which will automatically have
correct width based on number of split open in your current window)
  + Changed 'wincmd W' to 'wincmd w' just for precaution
  + Added check while closing the scratch buffer, if user is in scratch
buffer then it used get error. Thus now it will switch to other buffer
and then it will close the scratch buffer.